### PR TITLE
don't sync on ntp KoD packets

### DIFF
--- a/WThermostat/src/WClock.h
+++ b/WThermostat/src/WClock.h
@@ -121,12 +121,17 @@ public:
 				WiFiUDP ntpUDP;
 				NTPClient ntpClient(ntpUDP, ntpServer->c_str());
 				if (ntpClient.update()) {
-					lastNtpSync = millis();
-					ntpTime = ntpClient.getEpochTime();
-					this->calculateDstStartAndEnd();
-					validTime->setBoolean(!this->useTimeZoneServer->getBoolean());
-					network->debug(F("NTP time synced: %s"), epochTimeFormatted->c_str());
-					timeUpdated = true;
+					ntpEpoch = ntpClient.getEpochTime();
+					if (ntpEpoch + SEVENZYYEARS != 0){
+						lastNtpSync = millis();
+						ntpTime = ntpEpoch;
+						this->calculateDstStartAndEnd();
+						validTime->setBoolean(!this->useTimeZoneServer->getBoolean());
+						network->debug(F("NTP time synced: %s"), epochTimeFormatted->c_str());
+						timeUpdated = true;
+					} else {
+						network->error(F("NTP sync failed with 0 epoch."));
+					}
 				} else {
 					network->error(F("NTP sync failed. "));
 				}
@@ -465,7 +470,7 @@ public:
 
 private:
 	THandlerFunction onTimeUpdate;
-	unsigned long lastTry, lastNtpSync, lastTimeZoneSync, ntpTime;
+	unsigned long lastTry, lastNtpSync, lastTimeZoneSync, ntpTime, ntpEpoch;
 	unsigned long dstStart, dstEnd;
 	byte failedTimeZoneSync;
 	WProperty* epochTime;


### PR DESCRIPTION
This ignores ntp responses with a 0 epoch (which is returned with a [stratum 0 as KissOfDeath](https://de.wikipedia.org/wiki/Kiss-of-death_Packet)) and prevents the date to jump to 2036.

This should be fixed upstream, but the [corresponding PR](https://github.com/arduino-libraries/NTPClient/pull/28/files) is open since 2017.